### PR TITLE
Cope with output directories that are badly formatted

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -22,9 +22,14 @@
             {% for output in outputs %}
                 <div class="card {% if loop.first %}bg-primary{% endif %}" style="width: 25%;">
                     <div class="card-body">
-                        <h5 class="card-title">{{ output.date_display }}</h5>
-                        <a href="{{ url_for('output', path=output.html_path) }}" class="card-link">Animation</a>
-                        <a href="{{ url_for('output', path=output.log_path) }}" class="card-link">Logs</a>
+                        {% if output.is_valid() %}
+                            <h5 class="card-title">{{ output.date_display }}</h5>
+                            <a href="{{ url_for('output', path=output.html_path) }}" class="card-link">Animation</a>
+                            <a href="{{ url_for('output', path=output.log_path) }}" class="card-link">Logs</a>
+                        {% else %}
+                            <h5 class="card-title">{{ output.path }}</h5>
+                            <p>Error</p>
+                        {% endif %}
                     </div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
Whether they're missing files or have names in an unexpected format this change means that they'll be displayed rather than causing the runner as a whole to error out.